### PR TITLE
[grid_map_core] makes the isInside checks const

### DIFF
--- a/grid_map_core/include/grid_map_core/Polygon.hpp
+++ b/grid_map_core/include/grid_map_core/Polygon.hpp
@@ -43,7 +43,7 @@ class Polygon
    * @param point the point to be checked.
    * @return true if inside, false otherwise.
    */
-  bool isInside(const Position& point);
+  bool isInside(const Position& point) const;
 
   /*!
    * Add a vertex to the polygon

--- a/grid_map_core/include/grid_map_core/iterators/CircleIterator.hpp
+++ b/grid_map_core/include/grid_map_core/iterators/CircleIterator.hpp
@@ -71,7 +71,7 @@ private:
    * Check if current index is inside the circle.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the circle and returns the parameters.

--- a/grid_map_core/include/grid_map_core/iterators/EllipseIterator.hpp
+++ b/grid_map_core/include/grid_map_core/iterators/EllipseIterator.hpp
@@ -73,7 +73,7 @@ private:
    * Check if current index is inside the ellipse.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the ellipse and returns the parameters.

--- a/grid_map_core/include/grid_map_core/iterators/PolygonIterator.hpp
+++ b/grid_map_core/include/grid_map_core/iterators/PolygonIterator.hpp
@@ -71,7 +71,7 @@ private:
    * Check if current index is inside polygon.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the polygon and returns the parameters.

--- a/grid_map_core/include/grid_map_core/iterators/SpiralIterator.hpp
+++ b/grid_map_core/include/grid_map_core/iterators/SpiralIterator.hpp
@@ -77,7 +77,7 @@ private:
    * Check if index is inside the circle.
    * @return true if inside, false otherwise.
    */
-  bool isInside(const Index index);
+  bool isInside(const Index index) const;
 
   /*!
    * Uses the current distance to get the points of a ring

--- a/grid_map_core/src/Polygon.cpp
+++ b/grid_map_core/src/Polygon.cpp
@@ -23,7 +23,7 @@ Polygon::Polygon(std::vector<Position> vertices)
 
 Polygon::~Polygon() {}
 
-bool Polygon::isInside(const Position& point)
+bool Polygon::isInside(const Position& point) const
 {
   int cross = 0;
   for (int i = 0, j = vertices_.size() - 1; i < vertices_.size(); j = i++) {

--- a/grid_map_core/src/iterators/CircleIterator.cpp
+++ b/grid_map_core/src/iterators/CircleIterator.cpp
@@ -71,7 +71,7 @@ bool CircleIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool CircleIterator::isInside()
+bool CircleIterator::isInside() const
 {
   Position position;
   getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/grid_map_core/src/iterators/EllipseIterator.cpp
+++ b/grid_map_core/src/iterators/EllipseIterator.cpp
@@ -76,7 +76,7 @@ bool EllipseIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool EllipseIterator::isInside()
+bool EllipseIterator::isInside() const
 {
   Position position;
   getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/grid_map_core/src/iterators/PolygonIterator.cpp
+++ b/grid_map_core/src/iterators/PolygonIterator.cpp
@@ -67,7 +67,7 @@ bool PolygonIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool PolygonIterator::isInside()
+bool PolygonIterator::isInside() const
 {
   Eigen::Vector2d position;
   getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/grid_map_core/src/iterators/SpiralIterator.cpp
+++ b/grid_map_core/src/iterators/SpiralIterator.cpp
@@ -70,7 +70,7 @@ bool SpiralIterator::isPastEnd() const
   return (distance_ == nRings_ && pointsRing_.empty());
 }
 
-bool SpiralIterator::isInside(const Index index)
+bool SpiralIterator::isInside(const Index index) const
 {
   Eigen::Vector2d position;
   getPositionFromIndex(position, index, mapLength_, mapPosition_, resolution_, bufferSize_);


### PR DESCRIPTION
To make this check usable when working with const grid maps.

This goes along with a similar [PR in cost_map](https://github.com/stonier/cost_map/pull/16).
